### PR TITLE
Topic/compat py3

### DIFF
--- a/cv_imshow.py
+++ b/cv_imshow.py
@@ -43,18 +43,20 @@ class cv_imshow(gdb.Command):
     def __init__(self):
         super(cv_imshow, self).__init__('cv_imshow',
                                         gdb.COMMAND_SUPPORT,
-                                        gdb.COMPLETE_FILENAME)
+                                        gdb.COMPLETE_SYMBOL)
 
     def invoke (self, arg, from_tty):
         # Access the variable from gdb.
-        frame = gdb.selected_frame()
-        val = frame.read_var(arg)
+        args = gdb.string_to_argv(arg)
+        val = gdb.parse_and_eval(args[0])
         if str(val.type.strip_typedefs()) == 'IplImage *':
             img_info = self.get_iplimage_info(val)
         else:
             img_info = self.get_cvmat_info(val)
 
         if img_info: self.show_image(*img_info)
+
+        self.dont_repeat()
 
     @staticmethod
     def get_cvmat_info(val):

--- a/cv_imshow.py
+++ b/cv_imshow.py
@@ -24,18 +24,21 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from builtins import str as text
+from builtins import range
+
 import gdb
 from PIL import Image
 import matplotlib
 matplotlib.use('TKAgg')
 import matplotlib.pyplot as pl
+
 import numpy as np
 import struct
 
 
-
 def chunker(seq, size):
-    return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))
+    return (seq[pos:pos + size] for pos in range(0, len(seq), size))
 
 class cv_imshow(gdb.Command):
     """Diplays the content of an opencv image"""
@@ -96,7 +99,7 @@ class cv_imshow(gdb.Command):
         gdb.write(cv_type_name + ' with ' + str(channels) + ' channels, ' +
                   str(rows) + ' rows and ' +  str(cols) +' cols\n')
 
-        data_address = unicode(val['data']).encode('utf-8').split()[0]
+        data_address = text(val['data']).encode('utf-8').split()[0]
         data_address = int(data_address, 16)
 
         return (cols, rows, channels, line_step, data_address, data_symbol)
@@ -144,7 +147,7 @@ class cv_imshow(gdb.Command):
         gdb.write(cv_type_name + ' with ' + str(channels) + ' channels, ' +
                   str(rows) + ' rows and ' +  str(cols) +' cols\n')
 
-        data_address = unicode(val['imageData']).encode('utf-8').split()[0]
+        data_address = text(val['imageData']).encode('utf-8').split()[0]
         data_address = int(data_address, 16)
         if str(val['roi']) != '0x0':
             x_offset = int(val['roi']['xOffset'])
@@ -227,7 +230,7 @@ class cv_imshow(gdb.Command):
 
         if n_channel == 3:
             # OpenCV stores the channels in BGR mode. Convert to RGB while packing.
-            image_data = zip(*[image_data[i::3] for i in [2, 1, 0]])
+            image_data = list(zip(*[image_data[i::3] for i in [2, 1, 0]]))
 
         # Show image.
         img = Image.new(mode, (width, height))

--- a/cv_imshow.py
+++ b/cv_imshow.py
@@ -26,8 +26,12 @@
 
 import gdb
 from PIL import Image
-import pylab as pl
+import matplotlib
+matplotlib.use('TKAgg')
+import matplotlib.pyplot as pl
+import numpy as np
 import struct
+
 
 
 def chunker(seq, size):
@@ -226,7 +230,7 @@ class cv_imshow(gdb.Command):
         # Show image.
         img = Image.new(mode, (width, height))
         img.putdata(image_data)
-        img = pl.asarray(img);
+        img = np.asarray(img);
 
         fig = pl.figure()
         b = fig.add_subplot(111)

--- a/test.cpp
+++ b/test.cpp
@@ -36,8 +36,8 @@ using namespace cv;
 int main(int argc, char *argv[])
 {
 
-    Mat matImg = imread("../gogh.jpg", CV_LOAD_IMAGE_GRAYSCALE);
-    Mat matImg3 = imread("../gogh.jpg");
+    Mat matImg = imread("gogh.jpg", CV_LOAD_IMAGE_GRAYSCALE);
+    Mat matImg3 = imread("gogh.jpg");
 
     if (matImg.data == NULL) {
         cerr << "Error: Can't find file gogh.jpg" << endl;


### PR DESCRIPTION
More and more distributions are moving to gdb with python 3 included, and breaking this very useful gdb extension. This patch comes to enforce compatibility with both python 2/python 3
